### PR TITLE
Fixes a memory management error

### DIFF
--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -243,8 +243,17 @@ class Handle_%s : public Handle_%s {
     handle_body_template += """
 };
 %%extend Handle_%s {
-    %s* GetObject() {
+    %s* _get_reference() {
     return (%s*)$self->Access();
+    }
+};
+
+%%extend Handle_%s {
+    %%pythoncode {
+        def GetObject(self):
+            obj = self._get_reference()
+            register_handle(self, obj)
+            return obj
     }
 };
 
@@ -810,7 +819,7 @@ def process_function(f):
             except:
                 return False
         }
-        """ % param_type    
+        """ % param_type
     # special process for operator !=
     if "operator !=" in function_name:
         param = f["parameters"][0]
@@ -1015,7 +1024,7 @@ def build_inheritance_tree(classes_dict):
         elif nbr_upper_classes == 1:
             upper_class_name = upper_classes[0]["class"]
             # if the upper class depends on another module
-            # add it to the level 0 list. 
+            # add it to the level 0 list.
             if upper_class_name.split("_")[0] != CURRENT_MODULE:
                 level_0_classes.append(class_name)
             # else build the inheritance tree
@@ -1085,7 +1094,7 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         # for instance TopoDS is both a module and a class
         # then we rename the class with lowercase
         if class_name == CURRENT_MODULE:
-            class_def_str += "%%rename(%s) %s;\n" % (class_name.lower(), class_name)    
+            class_def_str += "%%rename(%s) %s;\n" % (class_name.lower(), class_name)
         # then process the class itself
         if not class_can_have_default_constructor(klass):
         #if not class_name in CLASSES_WITH_DEFAULT_CONSTRUCTORS:


### PR DESCRIPTION
This commit tries to fix the issue tpaviot/pythonocc-core#292. When we got a handle from an API function and called GetObject() the lifetime of the object was determined only by the handle. This lead to crashes, when only a reference to the object was stored. The commit registers the handle with its object to prevent premature destruction.

Sorry for the whitespace changes BTW.