### PR TITLE
Adding generation for typedef inside of a class

### DIFF
--- a/src/Modules.py
+++ b/src/Modules.py
@@ -562,7 +562,7 @@ OCE_MODULES = [
            ('Graphic3d', 
             ['TShort', 'TColQuantity'],
             ['Graphic3d_UniformValue', 'Graphic3d_UniformValueType',
-             'Graphic3d_ClipPlane', 'Graphic3d_UniformValueTypeID', 'Graphic3d_Buffer',
+             'Graphic3d_UniformValueTypeID', 'Graphic3d_Buffer',
              'Graphic3d_IndexBuffer'],
             {'Graphic3d_ShaderVariable': 'Create',
              'Graphic3d_ValueInterface': 'As',

--- a/src/contrib/cppheaderparser/CppHeaderParser/CppHeaderParser.py
+++ b/src/contrib/cppheaderparser/CppHeaderParser/CppHeaderParser.py
@@ -1879,7 +1879,7 @@ class _CppHeader( Resolver ):
                 typedef = self._parse_typedef( self.stack )
                 name = typedef['name']
                 klass = self.classes[ self.curClass ]
-                klass[ 'typedefs' ][ self.curAccessSpecifier ].append( typedef )
+                klass[ 'typedefs' ][ self.curAccessSpecifier ].append( name )
                 if self.curAccessSpecifier == 'public': klass._public_typedefs[ name ] = typedef['type']
                 Resolver.SubTypedefs[ name ] = self.curClass
             else: assert 0

--- a/src/contrib/cppheaderparser/CppHeaderParser/CppHeaderParser.py
+++ b/src/contrib/cppheaderparser/CppHeaderParser/CppHeaderParser.py
@@ -1879,7 +1879,7 @@ class _CppHeader( Resolver ):
                 typedef = self._parse_typedef( self.stack )
                 name = typedef['name']
                 klass = self.classes[ self.curClass ]
-                klass[ 'typedefs' ][ self.curAccessSpecifier ].append( name )
+                klass[ 'typedefs' ][ self.curAccessSpecifier ].append( typedef )
                 if self.curAccessSpecifier == 'public': klass._public_typedefs[ name ] = typedef['type']
                 Resolver.SubTypedefs[ name ] = self.curClass
             else: assert 0

--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -1138,6 +1138,13 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
             inheritance_access = inherits_from[0]["access"]
             class_def_str += " : %s %s" % (inheritance_access, inheritance_name)
         class_def_str += " {\n"
+        # process class typedefs here
+        typedef_str = ''
+        for typedef_value in list(klass["typedefs"]['public']):
+            if ')' in typedef_value['name']:
+                continue
+            typedef_str += "typedef %s %s;\n" % (typedef_value['type'], typedef_value['name'])
+        class_def_str += typedef_str
         # process class enums here
         class_enums_list = klass["enums"].items()[1][1]
         if class_enums_list:

--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -1141,9 +1141,9 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         # process class typedefs here
         typedef_str = ''
         for typedef_value in list(klass["typedefs"]['public']):
-            if ')' in typedef_value['name']:
+            if ')' in typedef_value:
                 continue
-            typedef_str += "typedef %s %s;\n" % (typedef_value['type'], typedef_value['name'])
+            typedef_str += "typedef %s %s;\n" % (klass._public_typedefs[typedef_value], typedef_value)
         class_def_str += typedef_str
         # process class enums here
         class_enums_list = klass["enums"].items()[1][1]


### PR DESCRIPTION
@tpaviot @jf--- here is the code that adds the missing typedefs, as far as a checked there are only 2, one is Equation from the clipplanes class and the other one is Target from the classes RepBuilderAPI_VertexInspector, BRepMesh_CircleInspector, BRepMesh_VertexInspector, I think this is related to the class NCollection_CellFilter class that is also excluded.