### PR TITLE
Newline added in module description generation

### DIFF
--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -708,7 +708,7 @@ def get_module_docstring(module_name):
                 line_to_append = line_to_append.lstrip()
                 line_to_append = line_to_append.rstrip()
                 docstr_l.append(line_to_append)
-    docstr = ''.join(docstr_l[2:])
+    docstr = '\n'.join(docstr_l[2:])
     return docstr
 
 


### PR DESCRIPTION
So now each line to append of the module description has a newline character.... 
The generated api doc looks much better now. 