### PR TITLE
Makes current version of pythonocc-core compilable with occt 7.5.2

### DIFF
--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -2771,7 +2771,7 @@ class ModuleWrapper:
             if self._module_name in ["BRepMesh", "XBRepMesh"]: # wrong header order with gcc4 issue #63
                 swig_interface_file.write("#include<BRepMesh_Delaun.hxx>\n")
             if self._module_name == "ShapeUpgrade":
-                swig_interface_file.write("#include<Precision.hxx>\n#include<ShapeUpgrade_UnifySameDomain.hxx>\n")
+                swig_interface_file.write("#include<Precision.hxx>\n#include<TopoDS_Edge.hxx>\n#include<ShapeUpgrade_UnifySameDomain.hxx>\n")
             module_headers = glob.glob('%s/%s_*.hxx' % (OCE_INCLUDE_DIR, self._module_name))
             module_headers += glob.glob('%s/%s.hxx' % (OCE_INCLUDE_DIR, self._module_name))
             module_headers.sort()


### PR DESCRIPTION
**Important**: This PR changes the output of the generator according to PR tpaviot/pythonocc-core#1040

Fixes problem mentioned in tpaviot/pythonocc-core#995 and https://forum.freecadweb.org/viewtopic.php?f=4&t=58090. Without fix, you end up with a compiler error
```
In file included from /home/mainuser/software/freecad_source/build_2021-04-25/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPy.h:8,
                 from /home/mainuser/software/freecad_source/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp:30:
/home/mainuser/software/occt-0dc2c37/include/opencascade/ShapeUpgrade_UnifySameDomain.hxx:72:15: error: field ‘UnionEdges’ has incomplete type ‘TopoDS_Edge’
   TopoDS_Edge UnionEdges;
               ^~~~~~~~~~
In file included from /home/mainuser/software/occt-0dc2c37/include/opencascade/BRepTools_History.hxx:20,
                 from /home/mainuser/software/occt-0dc2c37/include/opencascade/ShapeUpgrade_UnifySameDomain.hxx:20,
                 from /home/mainuser/software/freecad_source/build_2021-04-25/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPy.h:8,
                 from /home/mainuser/software/freecad_source/src/Mod/Part/App/ShapeUpgrade/UnifySameDomainPyImp.cpp:30:
/home/mainuser/software/occt-0dc2c37/include/opencascade/TopExp.hxx:31:7: note: forward declaration of ‘class TopoDS_Edge’
 class TopoDS_Edge;
       ^~~~~~~~~~~
```
