### PR TITLE
Fix bug in pickling TopoDS_Shape: orientation is not conserved

### DIFF
--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -2771,7 +2771,7 @@ class ModuleWrapper:
             if self._module_name in ["BRepMesh", "XBRepMesh"]: # wrong header order with gcc4 issue #63
                 swig_interface_file.write("#include<BRepMesh_Delaun.hxx>\n")
             if self._module_name == "ShapeUpgrade":
-                swig_interface_file.write("#include<Precision.hxx>\n#include<ShapeUpgrade_UnifySameDomain.hxx>\n")
+                swig_interface_file.write("#include<Precision.hxx>\n#include<TopoDS_Edge.hxx>\n#include<ShapeUpgrade_UnifySameDomain.hxx>\n")
             module_headers = glob.glob('%s/%s_*.hxx' % (OCE_INCLUDE_DIR, self._module_name))
             module_headers += glob.glob('%s/%s.hxx' % (OCE_INCLUDE_DIR, self._module_name))
             module_headers.sort()

--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -2561,10 +2561,10 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         class_pyi_str = class_pyi_str.replace('pass\n\t@overload', '@overload')
         class_pyi_str = class_pyi_str.replace('pass\n\tdef', 'def')
         class_pyi_str = class_pyi_str.replace('pass\n\t@staticmethod', '@staticmethod')
-        
-        # Important special case: For pickling of TopoDS_Shape, we do need WriteToString 
+
+        # Important special case: For pickling of TopoDS_Shape, we do need WriteToString
         #                         and ReadFromString.
-        if class_name == "BRepTools":                              
+        if class_name == "BRepTools":
             class_def_str += """                    
                     %feature("autodoc", "Serializes TopoDS_Shape to string") WriteToString;
                     %extend{
@@ -2623,12 +2623,12 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         if class_name == 'TopoDS_Shape':
             class_def_str += '%extend TopoDS_Shape {\n%pythoncode {\n'
             class_def_str += '\tdef __getstate__(self):\n'
-            class_def_str += '\t\tfrom .BRepTools import breptools_WriteToString\n'            
-            class_def_str += '\t\tstr_shape = breptools_WriteToString(self)\n'            
+            class_def_str += '\t\tfrom .BRepTools import breptools_WriteToString\n'
+            class_def_str += '\t\tstr_shape = breptools_WriteToString(self)\n'
             class_def_str += '\t\treturn str_shape\n'
             class_def_str += '\tdef __setstate__(self, state):\n'
-            class_def_str += '\t\tfrom .BRepTools import breptools_ReadFromString\n'                                    
-            class_def_str += '\t\tthe_shape = breptools_ReadFromString(state)\n'            
+            class_def_str += '\t\tfrom .BRepTools import breptools_ReadFromString\n'
+            class_def_str += '\t\tthe_shape = breptools_ReadFromString(state)\n'
             class_def_str += '\t\tself.this = the_shape.this\n'
             class_def_str += '\t}\n};\n'
         # for each class, overload the __repr__ method to avoid things like:


### PR DESCRIPTION
Please note

- this PR incorporates a commit proposed in PR #81 (Commit 6cfaad8)
- The changes caused by this changes in the generator are expressed in tpaviot/pythonocc-core#1042

Pickling of TopoDS_Shape instances now uses BRepTools::Write & BRepTools::Read, which - different to BRepTools_ShapeSet - conserves the object's orientation. In order to be able to use BRepTools::Write/Read I added two wrappers WriteToString/ReadFromString which reside in the breptools class and have an alias in the BRepTools 
module breptools_WriteToString and breptools_ReadFromString
