### PR TITLE
Pickling does not round

### DIFF
--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -2566,10 +2566,14 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         #                         and ReadFromString.
         if class_name == "BRepTools":
             class_def_str += """                    
-                    %feature("autodoc", "Serializes TopoDS_Shape to string") WriteToString;
+                    %feature("autodoc", "Serializes TopoDS_Shape to string. If full_precision is False, the default precision of std::stringstream is used which regularly causes rounding.") WriteToString;
                     %extend{
-                        static std::string WriteToString(const TopoDS_Shape & shape) {
+                        static std::string WriteToString(const TopoDS_Shape & shape, bool full_precision = true) {
                         std::stringstream s;
+                        if(full_precision) {
+                            s.precision(17);
+                            s.setf(std::ios::scientific);
+                        }
                         BRepTools::Write(shape, s);
                         return s.str();}
                     };
@@ -2624,7 +2628,7 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
             class_def_str += '%extend TopoDS_Shape {\n%pythoncode {\n'
             class_def_str += '\tdef __getstate__(self):\n'
             class_def_str += '\t\tfrom .BRepTools import breptools_WriteToString\n'
-            class_def_str += '\t\tstr_shape = breptools_WriteToString(self)\n'
+            class_def_str += '\t\tstr_shape = breptools_WriteToString(self, True)\n'
             class_def_str += '\t\treturn str_shape\n'
             class_def_str += '\tdef __setstate__(self, state):\n'
             class_def_str += '\t\tfrom .BRepTools import breptools_ReadFromString\n'

--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -2565,7 +2565,7 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         # Important special case: For pickling of TopoDS_Shape, we do need WriteToString
         #                         and ReadFromString.
         if class_name == "BRepTools":
-            class_def_str += """                    
+            class_def_str += """
                     %feature("autodoc", "Serializes TopoDS_Shape to string. If full_precision is False, the default precision of std::stringstream is used which regularly causes rounding.") WriteToString;
                     %extend{
                         static std::string WriteToString(const TopoDS_Shape & shape, bool full_precision = true) {
@@ -2594,7 +2594,7 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
             global CURRENT_MODULE_PYI_STATIC_METHODS_ALIASES
             CURRENT_MODULE_PYI_STATIC_METHODS_ALIASES += "breptools_WriteToString = breptools.WriteToString\n"
             CURRENT_MODULE_PYI_STATIC_METHODS_ALIASES += "breptools_ReadFromString = breptools.ReadFromString\n"
-            
+
         # a special wrapper template for TDF_Label
         # We add a special method for recovering label names
         if class_name == "TDF_Label":

--- a/src/generate_wrapper.py
+++ b/src/generate_wrapper.py
@@ -2561,10 +2561,10 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         class_pyi_str = class_pyi_str.replace('pass\n\t@overload', '@overload')
         class_pyi_str = class_pyi_str.replace('pass\n\tdef', 'def')
         class_pyi_str = class_pyi_str.replace('pass\n\t@staticmethod', '@staticmethod')
-        
-        # Important special case: For pickling of TopoDS_Shape, we do need WriteToString 
+
+        # Important special case: For pickling of TopoDS_Shape, we do need WriteToString
         #                         and ReadFromString.
-        if class_name == "BRepTools":                              
+        if class_name == "BRepTools":
             class_def_str += """                    
                     %feature("autodoc", "Serializes TopoDS_Shape to string") WriteToString;
                     %extend{
@@ -2623,12 +2623,12 @@ def process_classes(classes_dict, exclude_classes, exclude_member_functions):
         if class_name == 'TopoDS_Shape':
             class_def_str += '%extend TopoDS_Shape {\n%pythoncode {\n'
             class_def_str += '\tdef __getstate__(self):\n'
-            class_def_str += '\t\tfrom .BRepTools import breptools_WriteToString\n'            
-            class_def_str += '\t\tstr_shape = breptools_WriteToString(self)\n'            
+            class_def_str += '\t\tfrom .BRepTools import breptools_WriteToString\n'
+            class_def_str += '\t\tstr_shape = breptools_WriteToString(self)\n'
             class_def_str += '\t\treturn str_shape\n'
             class_def_str += '\tdef __setstate__(self, state):\n'
-            class_def_str += '\t\tfrom .BRepTools import breptools_ReadFromString\n'                                    
-            class_def_str += '\t\tthe_shape = breptools_ReadFromString(state)\n'            
+            class_def_str += '\t\tfrom .BRepTools import breptools_ReadFromString\n'
+            class_def_str += '\t\tthe_shape = breptools_ReadFromString(state)\n'
             class_def_str += '\t\tself.this = the_shape.this\n'
             class_def_str += '\t}\n};\n'
         # for each class, overload the __repr__ method to avoid things like:


### PR DESCRIPTION
Up until now pickling rounded the shape. In our application this lead to slight differences between calculations done in the same process and calculations done in a subprocess (which was communicated with via pickle/unpickle). Building on top of PR #1042 I added an option to breptools_WriteToString to have full precision. In this case then the writing is done with a stringstream using 17 digits and a scientific floating point format. 

Perhaps - this would be a design decision up to you - it's more reasonable to always use full precision in breptools_WriteToString. I already made `full_precision = True` the default. My idea was that someone might still want to be able to exactly reproduce previously written brep files. 

Please note that 

- this PR is based upon previously commited PRs #81 and #82 
- the actual change of the code files is contained in a PR in pythonocc-core. See reference below
